### PR TITLE
Update `macos-setup.sh` To be Idempotent

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -1,4 +1,5 @@
 alias commits='git log --pretty=oneline | head -n'
-alias work='cd ~/Code/archera/reserved-ai/'
 alias blog='cd ~/Code/personal-projects/nwcalvank.dev/'
 alias compiler='cd ~/Code/personal-projects/writing_an_interpreter_in_go_1.7/my-code/'
+alias dev='cd ~/Code/development-environment/'
+alias work='cd ~/Code/archera/reserved-ai/'

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,10 @@ setup:
 
 sync:
 	make sync-bash
+	make sync-zsh
 	make sync-vim
 	make sync-neovim
-	make sync-zsh
+	make sync-packer
 
 sync-bash:
 	cp .aliases ~/.aliases
@@ -15,6 +16,9 @@ sync-bash:
 sync-neovim:
 	mkdir -p ~/.config
 	cp -r nvim ~/.config/
+
+sync-packer:
+	nvim +PackerSync
 
 sync-vim:
 	cp .vimrc-local ~/.vimrc

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+setup:
+	. ./macos-setup.sh
+
 sync:
 	make sync-bash
 	make sync-vim

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ that (if you use Neovim and happen to share all of my current preferences).
 ```bash
 git clone https://github.com/nwcalvank/development-environment.git
 cd development-environment
-. ./macos-setup.sh
+make setup
 ```
 
 You'll be prompted to provide a password to install Homebrew.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,18 @@ When making changes to your development environment, you can update the files
 directly in this repo, and then run the provided Make commands to sync the
 relevant configuration.
 
+To sync everything, you can simply re-run the setup command:
+```
+make setup
+```
+
+Or to only update Shell & (Neo)Vim settings:
+```
+make sync
+```
+
+See Makefile for the list of more precise sync commands.
+
 ## Credits
 
 After years of neglect, I have updated this setup using inspiration from:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ that (if you use Neovim and happen to share all of my current preferences).
 
 ```bash
 git clone https://github.com/nwcalvank/development-environment.git
-cd development-environment && ./macos-setup.sh
+cd development-environment
+. ./macos-setup.sh
 ```
 
 You'll be prompted to provide a password to install Homebrew.

--- a/macos-setup.sh
+++ b/macos-setup.sh
@@ -24,7 +24,6 @@ brew install eksctl
 brew install gcc
 brew install gdbm
 brew install gettext
-brew install gh
 brew install giflib
 brew install git
 brew install gmp
@@ -39,7 +38,7 @@ brew install krb5
 brew install kubernetes-cli
 brew install nasm
 brew install neovim
-brew install postgresql
+brew install postgresql@14
 brew install ripgrep
 brew install tree-sitter
 brew install watch
@@ -50,18 +49,6 @@ brew install argo
 brew install pulumi
 
 # Clean up
-brew uninstall node
-brew uninstall postgresql@14
-brew uninstall pyenv
-brew uninstall pyenv-virtualenv
-brew uninstall python
-brew uninstall python@3.10
-brew uninstall python@3.9
-brew uninstall redis
-brew uninstall sqlite
-brew uninstall the_silver_searcher
-
-brew uninstall --cask sublime-text
 brew cleanup
 
 # Set up Bash Shell

--- a/macos-setup.sh
+++ b/macos-setup.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-chsh -s /bin/bash
+chsh -s /bin/zsh # Change to /bin/bash if using bash
 
 # Install Homebrew
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
@@ -23,20 +23,23 @@ brew install ripgrep
 brew install watch
 brew cleanup
 
-# Set up Bash Terminal
+# Set up Bash Shell
 make sync-bash
 
 # Set up Vim
 make sync-vim
 
+# Set up Neovim
+make sync-neovim
+
+# Set up zsh Shell
+make sync-zsh
+
 # Set up Node
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.2/install.sh | bash
-source ~/.bash_profile
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
+source ~/.zshrc # Change to ~/.bash_profile if using bash
 nvm install node  # install latest version
 nvm install --lts # install LTS version
-
-# Set Up Neovim
-make sync-neovim
 
 # Set Up Local git Config
 git config --global user.name "Nathan Calvank"

--- a/macos-setup.sh
+++ b/macos-setup.sh
@@ -1,26 +1,67 @@
 #!/bin/sh
-chsh -s /bin/zsh # Change to /bin/bash if using bash
 
 # Install Homebrew
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
 # Install Some Apps I Like
+brew install --cask adoptopenjdk8
 brew install --cask alfred
 brew install --cask docker
 brew install --cask google-chrome
 brew install --cask slack
 brew install --cask spotify
 brew install --cask iterm2
+brew install --cask visual-studio-code
 
 # Install Other Tools
+brew install aws-iam-authenticator
 brew install bash-completion
+brew install brotli
+brew install c-ares
+brew install ca-certificates
+brew install cmake
+brew install eksctl
+brew install gcc
+brew install gdbm
+brew install gettext
+brew install gh
+brew install giflib
 brew install git
+brew install gmp
 brew install go
+brew install icu4c
+brew install isl
+brew install jpeg
+brew install jpeg-turbo
 brew install jq
+brew install k9s
+brew install krb5
+brew install kubernetes-cli
 brew install nasm
 brew install neovim
+brew install postgresql
 brew install ripgrep
+brew install tree-sitter
 brew install watch
+brew install yarn
+
+# Install Work Tools
+brew install argo
+brew install pulumi
+
+# Clean up
+brew uninstall node
+brew uninstall postgresql@14
+brew uninstall pyenv
+brew uninstall pyenv-virtualenv
+brew uninstall python
+brew uninstall python@3.10
+brew uninstall python@3.9
+brew uninstall redis
+brew uninstall sqlite
+brew uninstall the_silver_searcher
+
+brew uninstall --cask sublime-text
 brew cleanup
 
 # Set up Bash Shell


### PR DESCRIPTION
## Description
This updates the MacOS setup script to be able to be run repeatedly on an already-configured machine.

It will update any outdated packages and sync all shell configuration.

It will also install any new packages.

I'd like to clean up the NVM setup. Maybe the look into a proper Python environment will give me some ideas.

## TODO
- [x] Support repeated executions
- [x] Update Homebrew list to reflect desired state of current machine (uninstall unwanted packages and include all wanted packages)
- [ ] Optional: Consider adding a prompt to provide your name to be passed to the git config file