### PR TITLE
Fix Setup w/ Bash & Brew for M1

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -1,6 +1,9 @@
 source ~/.aliases
 source ~/.bash_prompt
 
+# Set PATH, MANPATH, etc., for Homebrew.
+eval "$(/opt/homebrew/bin/brew shellenv)"
+
 # export PATH with local python installation
 export PATH="/usr/local/opt/python/libexec/bin:$PATH"
 
@@ -11,20 +14,3 @@ export NVM_DIR="$HOME/.nvm"
 # Set neovim as default text editor
 export VISUAL=nvim
 export EDITOR="$VISUAL"
-
-# AWS 2FA
-function aws-login() {
-  unset AWS_PROFILE
-
-  res=$(aws sts get-session-token --serial-number arn:aws:iam::967800896805:mfa/nathan-user --token-code "$1")
-
-  AWS_ACCESS_KEY_ID=$(echo $res | jq -r '.Credentials.AccessKeyId')
-  AWS_SECRET_ACCESS_KEY=$(echo $res | jq -r '.Credentials.SecretAccessKey')
-  AWS_SESSION_TOKEN=$(echo $res | jq -r '.Credentials.SessionToken')
-
-  aws configure set --profile mfa aws_access_key_id $AWS_ACCESS_KEY_ID
-  aws configure set --profile mfa aws_secret_access_key $AWS_SECRET_ACCESS_KEY
-  aws configure set --profile mfa aws_session_token $AWS_SESSION_TOKEN
-
-  export AWS_PROFILE=mfa
-}

--- a/.zshrc
+++ b/.zshrc
@@ -1,5 +1,8 @@
 source ~/.aliases
 
+# Set PATH, MANPATH, etc., for Homebrew.
+eval "$(/opt/homebrew/bin/brew shellenv)"
+
 # >>> conda initialize >>>
 # !! Contents within this block are managed by 'conda init' !!
 __conda_setup="$('/Users/nathancalvank/opt/anaconda3/bin/conda' 'shell.zsh' 'hook' 2> /dev/null)"
@@ -15,7 +18,6 @@ fi
 unset __conda_setup
 # <<< conda initialize <<<
 
-
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
 [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
@@ -30,3 +32,20 @@ COLOR_GIT='%F{46}'
 NEWLINE=$'\n'
 setopt PROMPT_SUBST
 export PROMPT='${COLOR_DIR}%d ${COLOR_GIT}$(parse_git_branch)${COLOR_DEF}${NEWLINE}%% '
+
+# AWS 2FA
+function aws-login() {
+  unset AWS_PROFILE
+
+  res=$(aws sts get-session-token --serial-number arn:aws:iam::967800896805:mfa/nathan-user --token-code "$1")
+
+  AWS_ACCESS_KEY_ID=$(echo $res | jq -r '.Credentials.AccessKeyId')
+  AWS_SECRET_ACCESS_KEY=$(echo $res | jq -r '.Credentials.SecretAccessKey')
+  AWS_SESSION_TOKEN=$(echo $res | jq -r '.Credentials.SessionToken')
+
+  aws configure set --profile mfa aws_access_key_id $AWS_ACCESS_KEY_ID
+  aws configure set --profile mfa aws_secret_access_key $AWS_SECRET_ACCESS_KEY
+  aws configure set --profile mfa aws_session_token $AWS_SESSION_TOKEN
+
+  export AWS_PROFILE=mfa
+}

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,57 @@
+install:
+	# Upgrade all existing apps, if any
+	brew upgrade
+
+	# Install Some Apps I Like
+	brew install --cask adoptopenjdk8
+	brew install --cask alfred
+	brew install --cask docker
+	brew install --cask google-chrome
+	brew install --cask slack
+	brew install --cask spotify
+	brew install --cask iterm2
+	brew install --cask visual-studio-code
+
+	# Install Other Tools
+	brew install awscli
+	brew install aws-iam-authenticator
+	brew install bash-completion
+	brew install brotli
+	brew install c-ares
+	brew install ca-certificates
+	brew install cmake
+	brew install eksctl
+	brew install gcc
+	brew install gdbm
+	brew install gettext
+	brew install giflib
+	brew install git
+	brew install gmp
+	brew install go
+	brew install icu4c
+	brew install isl
+	brew install jpeg
+	brew install jpeg-turbo
+	brew install jq
+	brew install k9s
+	brew install krb5
+	brew install kubernetes-cli
+	brew install nasm
+	brew install neovim
+	brew install postgresql@14
+	brew install python
+	brew install ripgrep
+	brew install tree-sitter
+	brew install watch
+	brew install yarn
+
+	# Install Work Tools
+	brew install argo
+	brew install pulumi
+
+	# Clean up
+	brew cleanup
+
 setup:
 	. ./macos-setup.sh
 
@@ -26,3 +80,7 @@ sync-vim:
 sync-zsh:
 	cp .aliases ~/.aliases
 	cp .zshrc ~/.zshrc
+
+update:
+	make install
+	make sync

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ that (if you use Neovim and happen to share all of my current preferences).
 
 ## MacOS
 
+In a bash terminal (must be bash!):
+
 ```bash
 git clone https://github.com/nwcalvank/development-environment.git
 cd development-environment
@@ -23,14 +25,9 @@ When making changes to your development environment, you can update the files
 directly in this repo, and then run the provided Make commands to sync the
 relevant configuration.
 
-To sync everything, you can simply re-run the setup command:
+To update everything, you can simply run the update command:
 ```
-make setup
-```
-
-Or to only update Shell & (Neo)Vim settings:
-```
-make sync
+make update
 ```
 
 See Makefile for the list of more precise sync commands.

--- a/macos-setup.sh
+++ b/macos-setup.sh
@@ -1,55 +1,16 @@
 #!/bin/sh
 
+# Uninstall Homebrew
+# /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall.sh)"
+
 # Install Homebrew
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
-# Install Some Apps I Like
-brew install --cask adoptopenjdk8
-brew install --cask alfred
-brew install --cask docker
-brew install --cask google-chrome
-brew install --cask slack
-brew install --cask spotify
-brew install --cask iterm2
-brew install --cask visual-studio-code
+# Set PATH, MANPATH, etc., for Homebrew.
+eval "$(/opt/homebrew/bin/brew shellenv)"
 
-# Install Other Tools
-brew install aws-iam-authenticator
-brew install bash-completion
-brew install brotli
-brew install c-ares
-brew install ca-certificates
-brew install cmake
-brew install eksctl
-brew install gcc
-brew install gdbm
-brew install gettext
-brew install giflib
-brew install git
-brew install gmp
-brew install go
-brew install icu4c
-brew install isl
-brew install jpeg
-brew install jpeg-turbo
-brew install jq
-brew install k9s
-brew install krb5
-brew install kubernetes-cli
-brew install nasm
-brew install neovim
-brew install postgresql@14
-brew install ripgrep
-brew install tree-sitter
-brew install watch
-brew install yarn
-
-# Install Work Tools
-brew install argo
-brew install pulumi
-
-# Clean up
-brew cleanup
+# Install apps & tools
+make install
 
 # Set up Bash Shell
 make sync-bash
@@ -65,7 +26,7 @@ make sync-zsh
 
 # Set up Node
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
-source ~/.zshrc # Change to ~/.bash_profile if using bash
+source ~/.bash_profile
 nvm install node  # install latest version
 nvm install --lts # install LTS version
 


### PR DESCRIPTION
I've split out the setup and maintenance commands because the setup script needs to be run in a Bash terminal, but I want the maintenance script (for updating packages & syncing configuration) to be shell-agnostic.

There were also some issues with running Homebrew and treesitter on an M1 chip, so those required fresh installs + a magic shell `eval` command, which I've added.