### PR TITLE
Add Terminal Mode Remaps

### DIFF
--- a/nvim/lua/nwcalvank/remap.lua
+++ b/nvim/lua/nwcalvank/remap.lua
@@ -12,3 +12,9 @@ vim.keymap.set("n", "<leader>Y", [["+Y]])
 -- Split
 vim.keymap.set("n", "<leader>ss", vim.cmd.split)
 vim.keymap.set("n", "<leader>vv", vim.cmd.vsplit)
+
+-- Terminal
+vim.keymap.set("n", "<leader>t", [[:split<enter>:terminal<enter>A]])  -- enter terminal split
+vim.keymap.set("n", "<leader>T", [[:vsplit<enter>:terminal<enter>A]]) -- enter terminal vsplit
+vim.keymap.set("t", "<esc>", [[<C-\><C-n>]])                          -- leave terminal mode
+vim.keymap.set("t", "<esc><esc>", [[<C-\><C-n>:q<enter>]])            -- leave & close terminal


### PR DESCRIPTION
This should make `:terminal` ergonomic enough for me to actually use it.

As a Neovim remap noob, I've probably written this in the jankiest way, but it works, so :shipit: 