### PR TITLE
Fix `:wqa` Error By Destroying Terminal Buffer

### DIFF
--- a/nvim/lua/nwcalvank/remap.lua
+++ b/nvim/lua/nwcalvank/remap.lua
@@ -17,4 +17,4 @@ vim.keymap.set("n", "<leader>vv", vim.cmd.vsplit)
 vim.keymap.set("n", "<leader>t", [[:split<enter>:terminal<enter>A]])  -- enter terminal split
 vim.keymap.set("n", "<leader>T", [[:vsplit<enter>:terminal<enter>A]]) -- enter terminal vsplit
 vim.keymap.set("t", "<esc>", [[<C-\><C-n>]])                          -- leave terminal mode
-vim.keymap.set("t", "<esc><esc>", [[<C-\><C-n>:q<enter>]])            -- leave & close terminal
+vim.keymap.set("t", "<esc><esc>", [[<C-\><C-n>:bd!<enter>]])          -- leave & close terminal


### PR DESCRIPTION
When a `:terminal` buffer is closed with `:q`, it still lives as a modified but unwritable buffer. This causes an error when running `:wqa`.

To avoid this, forcibly destroy the terminal buffer when closing the terminal.