### PR TITLE
Add Naive Rust Installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ install:
 	brew install postgresql@14
 	brew install python
 	brew install ripgrep
+	brew install rustup
 	brew install tree-sitter
 	brew install watch
 	brew install yarn


### PR DESCRIPTION
Manually ran `rustup-init` after installing. Leaving that out because it's trivial, and I'm not sure that I even should have run that.