### PR TITLE
Add `aws ec2` CLI Instance Helper Function

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -1,4 +1,7 @@
+# Github
 alias commits='git log --pretty=oneline | head -n'
+
+# Change Directory
 alias blog='cd ~/Code/personal-projects/nwcalvank.dev/'
 alias compiler='cd ~/Code/personal-projects/writing_an_interpreter_in_go_1.7/my-code/'
 alias dev='cd ~/Code/development-environment/'

--- a/.zshrc
+++ b/.zshrc
@@ -49,3 +49,8 @@ function aws-login() {
 
   export AWS_PROFILE=mfa
 }
+
+# AWS CLI Helpers
+function aws-instances() {
+    aws ec2 describe-instance-type-offerings --location-type availability-zone --filters=Name=instance-type,Values="$2" --region "$1" --output table
+}


### PR DESCRIPTION
This makes it easy to quickly change which AZs support certain instance types before attempting to deploy an EKS Cluster to that region.

Credit: https://coding-stream-of-consciousness.com/2021/08/27/listing-supported-availability-zones-azs-for-instance-types-in-aws/