### PR TITLE
Fix Python Installation & Other Stuff

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -1,5 +1,7 @@
 # Github
 alias commits='git log --pretty=oneline | head -n'
+alias staging='API_URL=http://localhost:5002 make start'
+alias production='API_URL=http://localhost:5003 make start'
 
 # Change Directory
 alias blog='cd ~/Code/personal-projects/nwcalvank.dev/'

--- a/.bash_profile
+++ b/.bash_profile
@@ -4,8 +4,8 @@ source ~/.bash_prompt
 # Set PATH, MANPATH, etc., for Homebrew.
 eval "$(/opt/homebrew/bin/brew shellenv)"
 
-# export PATH with local python installation
-export PATH="/usr/local/opt/python/libexec/bin:$PATH"
+# Make python3 the default python
+export PATH="/opt/homebrew/opt/python/libexec/bin:$PATH"
 
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm

--- a/.zshrc
+++ b/.zshrc
@@ -3,24 +3,16 @@ source ~/.aliases
 # Set PATH, MANPATH, etc., for Homebrew.
 eval "$(/opt/homebrew/bin/brew shellenv)"
 
-# >>> conda initialize >>>
-# !! Contents within this block are managed by 'conda init' !!
-__conda_setup="$('/Users/nathancalvank/opt/anaconda3/bin/conda' 'shell.zsh' 'hook' 2> /dev/null)"
-if [ $? -eq 0 ]; then
-    eval "$__conda_setup"
-else
-    if [ -f "/Users/nathancalvank/opt/anaconda3/etc/profile.d/conda.sh" ]; then
-        . "/Users/nathancalvank/opt/anaconda3/etc/profile.d/conda.sh"
-    else
-        export PATH="/Users/nathancalvank/opt/anaconda3/bin:$PATH"
-    fi
-fi
-unset __conda_setup
-# <<< conda initialize <<<
+# Make python3 the default python
+export PATH="/opt/homebrew/opt/python/libexec/bin:$PATH"
 
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
 [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+
+# Set neovim as default text editor
+export VISUAL=nvim
+export EDITOR="$VISUAL"
 
 # Git Branch
 parse_git_branch() {
@@ -38,9 +30,11 @@ export XDG_CONFIG_HOME="$HOME/.config"
 
 # AWS 2FA
 function aws-login-archera() {
-    SERIAL_NUMBER=$(aws configure get --profile archera mfa_serial)
+    SERIAL_NUMBER=$(aws configure get --profile archera-mfa mfa_serial)
+    ROLE=$(aws configure get --profile archera-mfa role_arn)
+    SESSION=$(aws configure get --profile archera-mfa role_session_name)
 
-    res=$(aws sts get-session-token --profile archera --serial-number $SERIAL_NUMBER --token-code "$1")
+    res=$(aws sts assume-role --profile archera --duration-seconds 43200 --serial-number $SERIAL_NUMBER --role-session-name $SESSION --role-arn $ROLE --token-code "$1")
 
     AWS_ACCESS_KEY_ID=$(echo $res | jq -r '.Credentials.AccessKeyId')
     AWS_SECRET_ACCESS_KEY=$(echo $res | jq -r '.Credentials.SecretAccessKey')

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 install:
 	# Upgrade all existing apps, if any
+	brew update
 	brew upgrade
 
 	# Install Some Apps I Like


### PR DESCRIPTION
Frankly, I've never bothered to learn how Python installations work, and I don't really care to. I just want to be able to run `python` in the terminal, and I was briefly unable to do so - as only `python3` was working.

This fixes that issue.

Notable change is updating the `PATH` for Applie Silicon, I believe.