### PR TITLE
Add Alias using `PRIMARY_PROJECT`

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -17,6 +17,7 @@ alias production='API_URL=http://localhost:5003 make start'
 
 # Change Directory
 alias blog='cd ~/Code/personal-projects/nwcalvank.dev/'
+alias code='cd ~/Code/$PRIMARY_PROJECT'
 alias dev='cd ~/Code/development-environment/'
 alias rust='cd ~/Code/personal-projects/rust/'
 alias work='cd ~/Code/archera/reserved-ai/server && archera'

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ install:
 	# Install Work Apps
 	brew install --cask aws-vpn-client
 	brew install --cask google-cloud-sdk
+	brew install --cask microsoft-teams
 	gcloud components install gke-gcloud-auth-plugin
 
 	# Install Other Tools


### PR DESCRIPTION
This works as a basic proof of concept for profile-specific aliases.

It would allow me to use the same commands for both staging and personal work, without having to hardocde everything in git

Oh, and toss Microsoft Teams in to Homebrew management.