### PR TITLE
Feat/UI: Automatically Toggle Light & Dark

### DIFF
--- a/nvim/lua/plugins/editor-ui.lua
+++ b/nvim/lua/plugins/editor-ui.lua
@@ -1,3 +1,9 @@
+-- Configure Editor Colours
+vim.g.circadian_day_start = 8
+vim.g.circadian_night_start = 17
+vim.g.circadian_day_theme = 'github_light'
+vim.g.circadian_night_theme = 'nightfox'
+
 return {
     -- Fancier statusline
     {
@@ -13,6 +19,8 @@ return {
     },
 
     -- Colour & Font Styles
+    {   'adamnsch/vim-circadian' },
+    {   'projekt0n/github-nvim-theme', name = 'github-theme' },
     {
         "EdenEast/nightfox.nvim",
         lazy = false, -- make sure we load this during startup if it is your main colorscheme


### PR DESCRIPTION
During the day, use a light theme (picked without much research at the moment). During the night, continue using old faithful: `nightfox`

I've updated the day to start at 8am and end at 5pm because the sun sets very early right now